### PR TITLE
Add fall through comment to appease ErrorProne

### DIFF
--- a/src/main/java/org/codehaus/stax2/ri/typed/StringBase64Decoder.java
+++ b/src/main/java/org/codehaus/stax2/ri/typed/StringBase64Decoder.java
@@ -147,7 +147,7 @@ public final class StringBase64Decoder
                     // otherwise, our triple is now complete
                     _decodedData = (_decodedData << 6) | bits;
                 }
-                // still along fast path
+                // fall through, still along fast path
 
             case STATE_OUTPUT_3:
                 if (resultOffset >= resultBufferEnd) { // no room


### PR DESCRIPTION
Compiling with error prone (the default with Bazel) complains because one of the case doesn't have "fall-through".

```
StringBase64Decoder.java:152: error: [FallThrough] Execution may fall through from the previous case; add a `// fall through` comment before this line if it was deliberate
            case STATE_OUTPUT_3:
            ^
    (see http://errorprone.info/bugpattern/FallThrough)
```