### PR TITLE
fix to write when standaloneSet - v3.1

### DIFF
--- a/src/main/java/org/codehaus/stax2/ri/Stax2EventWriterImpl.java
+++ b/src/main/java/org/codehaus/stax2/ri/Stax2EventWriterImpl.java
@@ -82,6 +82,8 @@ public class Stax2EventWriterImpl
                 StartDocument sd = (StartDocument) event;
                 if (!sd.encodingSet()) { // encoding defined?
                     mWriter.writeStartDocument(sd.getVersion());
+                } else if (sd.standaloneSet()) {
+                    mWriter.writeStartDocument(sd.getVersion(), sd.getCharacterEncodingScheme(), sd.isStandalone());                    
                 } else {
                     mWriter.writeStartDocument(sd.getCharacterEncodingScheme(),
                                                sd.getVersion());


### PR DESCRIPTION
In the current implementation has not possible to write standalone attribute in writeStartDocument. This pull request fix it.

`<?xml version='1.0' encoding='UTF-8' standalone='yes|no'?>`