### PR TITLE
Should be BSD license, not "BSF" license

### DIFF
--- a/src/main/resources/META-INF/LICENSE
+++ b/src/main/resources/META-INF/LICENSE
@@ -1,5 +1,5 @@
 This copy of Stax2 API is licensed under the
-Simplified BSF License (also known as "2-clause BSD", or "FreeBSD License")
+Simplified BSD License (also known as "2-clause BSD", or "FreeBSD License")
 See the License for details about distribution rights, and the
 specific rights regarding derivate works.
 


### PR DESCRIPTION
Not sure about whether "2010-" needs an end date. Also, "<OWNER>" should probably be "<COPYRIGHT HOLDER>" (per the BSD license). Didn't change either of those.