### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: java
 
+arch:
+  - AMD64
+  - ppc64le
+
 # 20-Mar-2019, tatu: While targets JDK 6, build now requires JDK 8
 jdk:
   - openjdk8


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.