### PR TITLE
Update README.md to add license info

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ Jars can be found from [Central Maven repo](http://repo1.maven.org/maven2/org/co
 
 Copyright (c) 2008 FasterXML LLC <info@fasterxml.com>
 
-This source code is licensed under standard BSD license, which is compatible with all Free and Open Software (OSS) licenses.
+This source code is licensed under standard Apache 2.0 license, which is an OSI and FSF approved Free Software license. 


### PR DESCRIPTION
The current statement in the README that this is BSD Licensed conflicts a bit with the use of the Apache 2.0 license that's been added. So I merely updated BSD to Apache 2.0. They are both permissive licenses, the good thing about the Apache 2.0 is that it also has a patent protection clause so it gives a little extra coverage. I also changed the rest of the sentence about licensing since while Apache 2.0 is a widely used, well known, Free Software license, it is not always compatible with every other FOSS license. In particular, you cannot use the Apache 2.0 with the GPLv2, but you can with a GPLv3. 

This is more licensing info than anyone ever wanted to know but it may be worth doing because I work for a company that was interested in using your software but felt unsure if they could given the license. Now they can.